### PR TITLE
Add support for MinimumWorkingSetSize

### DIFF
--- a/ProcessGovernor/ProcessGovernor.cs
+++ b/ProcessGovernor/ProcessGovernor.cs
@@ -181,6 +181,7 @@ namespace LowLevelDesign
                         PerProcessUserTimeLimit = 10_000 * ProcessUserTimeLimitInMilliseconds, // in 100ns
                         PerJobUserTimeLimit = 10_000 * JobUserTimeLimitInMilliseconds, // in 100ns
                         MaximumWorkingSetSize = (UIntPtr)MaxWorkingSetSize,
+                        MinimumWorkingSetSize = (UIntPtr)MinWorkingSetSize
                     },
                     ProcessMemoryLimit = (UIntPtr)MaxProcessMemory
                 };
@@ -330,6 +331,8 @@ namespace LowLevelDesign
         public ulong MaxProcessMemory { get; set; }
         
         public ulong MaxWorkingSetSize { get; set; }
+
+        public ulong MinWorkingSetSize { get; set; }
 
         public ushort NumaNode {
             get => numaNode;

--- a/ProcessGovernor/Program.cs
+++ b/ProcessGovernor/Program.cs
@@ -28,8 +28,10 @@ namespace LowLevelDesign
                 {
                     { "m|maxmem=", "Max committed memory usage in bytes (accepted suffixes: K, M, or G).",
                         v => { procgov.MaxProcessMemory = ParseMemoryString(v); } },
-                    { "maxws=", "Max working set size in bytes (accepted suffixes: K, M, or G).",
+                    { "maxws=", "Max working set size in bytes (accepted suffixes: K, M, or G). Must be set with minws.",
                         v => { procgov.MaxWorkingSetSize = ParseMemoryString(v); } },
+                    { "minws=", "Min working set size in bytes (accepted suffixes: K, M, or G). Must be set with maxws.",
+                        v => { procgov.MinWorkingSetSize = ParseMemoryString(v); } },
                     { "env=", "A text file with environment variables (each line in form: VAR=VAL). Applies only to newly created processes.",
                         v => LoadCustomEnvironmentVariables(procgov, v) },
                     { "n|node=", "The preferred NUMA node for the process.", 
@@ -87,6 +89,12 @@ namespace LowLevelDesign
                     Console.Error.WriteLine("ERROR: {0}", ex.Message);
                     Console.WriteLine();
                     showhelp = true;
+                }
+
+                if ((procgov.MaxWorkingSetSize > 0 && procgov.MinWorkingSetSize == 0) || (procgov.MinWorkingSetSize > 0 && procgov.MaxWorkingSetSize == 0))
+                {
+                    Console.Error.WriteLine("ERROR: minws and maxws must be set together.");
+                    return 1;
                 }
 
                 if (!showhelp && registryOperation != RegistryOperation.NONE) {
@@ -254,6 +262,8 @@ namespace LowLevelDesign
                 $"{procgov.CpuMaxRate}%" : "(not set)");
             Console.WriteLine("Maximum committed memory (MB):          {0}", procgov.MaxProcessMemory > 0 ?
                 $"{(procgov.MaxProcessMemory / 1048576):0,0}" : "(not set)");
+            Console.WriteLine("Minimum WS memory (MB):                 {0}", procgov.MinWorkingSetSize > 0 ?
+                $"{(procgov.MinWorkingSetSize / 1048576):0,0}" : "(not set)");
             Console.WriteLine("Maximum WS memory (MB):                 {0}", procgov.MaxWorkingSetSize > 0 ?
                 $"{(procgov.MaxWorkingSetSize / 1048576):0,0}" : "(not set)");
             Console.WriteLine("Preferred NUMA node:                    {0}", procgov.NumaNode != 0xffff ? 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Options:
   -m, --maxmem=VALUE         Max committed memory usage in bytes (accepted
                                suffixes: K, M or G).
       --maxws=VALUE          Max working set size in bytes (accepted
-                               suffixes: K, M, or G).
+                               suffixes: K, M, or G). Must be set with minws.
+      --minws=VALUE          Min working set size in bytes (accepted
+                               suffixes: K, M, or G). Must be set with maxws.
       --env=VALUE            A text file with environment variables (each
                                line in form: VAR=VAL). Applies only to newly
                                created processes.
@@ -62,6 +64,8 @@ Finally, it is possible to **run procgov always when a given process starts**. W
 ## Limit memory of a process
 
 With the **--maxmem** switch Process Governor allows you to set a limit on a memory committed by a process. On Windows committed memory is actually all private memory that the process uses. This way you may use Process Governor to test your .NET applications (including web applications) for memory leaks. If the process is leaking memory you faster get the **OutOfMemoryException**.
+
+With the **--maxws** and **--minws** switches you may control the maximum and minimum working set sizes of the process. If **--maxws** is > 0, **--minws** must also be > 0, and vice-versa.
 
 ## Limit CPU usage of a process (CPU affinity)
 


### PR DESCRIPTION
Adds support for MinimumWorkingSetSize. As described in the [docs](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_basic_limit_information) when MaximumWorkingSetSize is > 0,  MinimumWorkingSetSize must also be > 0 and vice-versa. This should fix #16.