### PR TITLE
ProcGov running as a debugger must pass a null-terminated string to the CreateProcess WIN32 function

### DIFF
--- a/procgov-tests/ProcessGovernorUnitTests.cs
+++ b/procgov-tests/ProcessGovernorUnitTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 
 namespace ProcessGovernor.Tests
@@ -112,6 +113,17 @@ namespace ProcessGovernor.Tests
             } finally {
                 File.Delete(envFilePath);
             }
+        }
+
+        [Test]
+        public void StartProcessTest()
+        {
+            var session = new SessionSettings();
+            var exception = Assert.Catch<Win32Exception>(() =>
+            {
+                ProcessModule.StartProcessUnderDebuggerAndAssignToJobObject(new[] { "test.exe" }, session);
+            });
+            Assert.AreEqual("The system cannot find the file specified.", exception?.Message);
         }
     }
 }

--- a/procgov/ProcessModule.cs
+++ b/procgov/ProcessModule.cs
@@ -271,7 +271,7 @@ internal static class ProcessModule
 
         fixed (char* penv = GetEnvironmentString(session.AdditionalEnvironmentVars))
         {
-            var args = string.Join(" ", procargs).ToCharArray();
+            var args = string.Join(" ", procargs, "\0").ToCharArray();
             fixed (char* pargs = args)
             {
                 var argsSpan = new Span<char>(pargs, args.Length);

--- a/procgov/ProcessModule.cs
+++ b/procgov/ProcessModule.cs
@@ -271,7 +271,7 @@ internal static class ProcessModule
 
         fixed (char* penv = GetEnvironmentString(session.AdditionalEnvironmentVars))
         {
-            var args = string.Join(" ", procargs, "\0").ToCharArray();
+            var args = (string.Join(" ", procargs.Select((string s) => s.Contains(' ') ? "\"" + s + "\"" : s)) + '\0').ToCharArray();
             fixed (char* pargs = args)
             {
                 var argsSpan = new Span<char>(pargs, args.Length);


### PR DESCRIPTION
Fixes issue #60, with a test to highlight the bug.